### PR TITLE
created statistics bar

### DIFF
--- a/components/StatisticsBar.tsx
+++ b/components/StatisticsBar.tsx
@@ -1,0 +1,81 @@
+
+"use client";
+
+import React, { useEffect, useState } from "react";
+
+export interface StatisticsBarProps {
+    percentage: number;
+  
+  colorGradient?: string;
+  
+  label?: string;
+  
+  animated?: boolean;
+  
+  animationDuration?: number;
+  
+  ariaLabel?: string;
+}
+
+const StatisticsBar: React.FC<StatisticsBarProps> = ({
+  percentage,
+  colorGradient = "from-gray-400 to-blue-500",
+  label,
+  animated = true,
+  animationDuration = 800,
+  ariaLabel,
+}) => {
+  // If animated: start at 0, then update to target. Otherwise start at target immediately.
+  const [progress, setProgress] = useState<number>(animated ? 0 : percentage);
+
+  useEffect(() => {
+    if (!animated) return;
+    const id = window.setTimeout(() => {
+      setProgress(percentage);
+    }, 50);
+    return () => window.clearTimeout(id);
+  }, [percentage, animated]);
+
+  
+  const safePct = Math.max(0, Math.min(100, progress));
+
+  return (
+    <div className="w-full">
+      {label && (
+        <div className="mb-1">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            {label}
+          </span>
+        </div>
+      )}
+
+      <div
+        role="progressbar"
+        aria-label={ariaLabel ?? "Progress"}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(safePct)}
+        className="w-full h-4 bg-gray-200 dark:bg-gray-700 rounded overflow-hidden"
+      >
+        <div
+          className={`
+            h-full 
+            bg-gradient-to-r ${colorGradient} 
+            rounded 
+            transition-[width] ease-in-out
+          `}
+          style={{
+            width: `${safePct}%`,
+            transitionDuration: `${animated ? animationDuration : 0}ms`,
+          }}
+        />
+      </div>
+
+      <div className="mt-1 text-right text-xs font-semibold text-gray-600 dark:text-gray-400">
+        {Math.round(safePct)}%
+      </div>
+    </div>
+  );
+};
+
+export default StatisticsBar;

--- a/components/StatisticsBar.tsx
+++ b/components/StatisticsBar.tsx
@@ -1,81 +1,121 @@
-
+// components/StatusBar.tsx
 "use client";
 
 import React, { useEffect, useState } from "react";
 
-export interface StatisticsBarProps {
-    percentage: number;
-  
-  colorGradient?: string;
-  
-  label?: string;
-  
+export type StatusType = "excellent" | "good" | "okay" | "poor" | "bad";
+
+export interface StatusBarProps {
+ 
+  status?: StatusType;
+
+ 
   animated?: boolean;
-  
+
+  /**
+   * Duration (ms) of the width transition if `animated=true`. Default: 800.
+   */
   animationDuration?: number;
-  
+
+  /**
+   * Override ARIA label (defaults to "Status Progress").
+   */
   ariaLabel?: string;
 }
 
-const StatisticsBar: React.FC<StatisticsBarProps> = ({
-  percentage,
-  colorGradient = "from-gray-400 to-blue-500",
-  label,
+const StatusBar: React.FC<StatusBarProps> = ({
+  status = "excellent",
   animated = true,
   animationDuration = 800,
   ariaLabel,
 }) => {
-  // If animated: start at 0, then update to target. Otherwise start at target immediately.
-  const [progress, setProgress] = useState<number>(animated ? 0 : percentage);
+  // Map status to percentage, gradient, and emoji
+  const mapping: Record<
+    StatusType,
+    { percentage: number; gradient: string; emoji: string }
+  > = {
+    excellent: {
+      percentage: 100,
+      gradient: "from-green-400 to-green-600",
+      emoji: "😄",
+    },
+    good: {
+      percentage: 75,
+      gradient: "from-lime-400 to-lime-600",
+      emoji: "😊",
+    },
+    okay: {
+      percentage: 50,
+      gradient: "from-yellow-300 to-yellow-500",
+      emoji: "😐",
+    },
+    poor: {
+      percentage: 25,
+      gradient: "from-orange-400 to-orange-600",
+      emoji: "😔",
+    },
+    bad: { percentage: 0, gradient: "from-red-400 to-red-600", emoji: "😢" },
+  };
+
+  const { percentage: targetPct, gradient, emoji } = mapping[status];
+
+  // Internal state to animate fill width
+  const [fill, setFill] = useState<number>(animated ? 0 : targetPct);
 
   useEffect(() => {
-    if (!animated) return;
+    if (!animated) {
+      setFill(targetPct);
+      return;
+    }
     const id = window.setTimeout(() => {
-      setProgress(percentage);
+      setFill(targetPct);
     }, 50);
     return () => window.clearTimeout(id);
-  }, [percentage, animated]);
-
-  
-  const safePct = Math.max(0, Math.min(100, progress));
+  }, [targetPct, animated]);
 
   return (
-    <div className="w-full">
-      {label && (
-        <div className="mb-1">
-          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-            {label}
-          </span>
-        </div>
-      )}
+    <div className="w-full space-y-1">
+      {/* Emoji + Status Label */}
+      <div className="flex items-center space-x-2">
+        <span className="text-xl">{emoji}</span>
+        <span className="font-medium text-gray-700 dark:text-gray-300 capitalize">
+          {status}
+        </span>
+      </div>
 
+      {/* Track (full gradient) */}
       <div
         role="progressbar"
-        aria-label={ariaLabel ?? "Progress"}
+        aria-label={ariaLabel ?? "Status Progress"}
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-valuenow={Math.round(safePct)}
-        className="w-full h-4 bg-gray-200 dark:bg-gray-700 rounded overflow-hidden"
+        aria-valuenow={Math.round(fill)}
+        className={`
+          w-full h-4 rounded overflow-hidden 
+          bg-gradient-to-r ${gradient}
+        `}
       >
+        {/* Gray “cover” on the right that shrinks as fill grows */}
         <div
-          className={`
-            h-full 
-            bg-gradient-to-r ${colorGradient} 
-            rounded 
-            transition-[width] ease-in-out
-          `}
+          className="h-full bg-gray-200 dark:bg-gray-700"
           style={{
-            width: `${safePct}%`,
-            transitionDuration: `${animated ? animationDuration : 0}ms`,
+            width: `${100 - fill}%`,
+            transition: animated
+              ? `width ${animationDuration}ms ease-in-out`
+              : undefined,
+            position: "absolute",
+            top: 0,
+            right: 0,
           }}
         />
       </div>
 
-      <div className="mt-1 text-right text-xs font-semibold text-gray-600 dark:text-gray-400">
-        {Math.round(safePct)}%
+      {/* Percentage Text */}
+      <div className="text-right text-xs font-semibold text-gray-600 dark:text-gray-400">
+        {Math.round(fill)}%
       </div>
     </div>
   );
 };
 
-export default StatisticsBar;
+export default StatusBar;


### PR DESCRIPTION
created a statistics bar for the emoji app using branch feature/statistics-bar attached is screenshots 
![Screenshot 2025-06-03 155539](https://github.com/user-attachments/assets/38d5bb4e-68c2-4cf7-85f2-7e8e75c94ef3)
![Screenshot 2025-06-03 155539](https://github.com/user-attachments/assets/e57ad186-8a54-4782-a368-377eb615f52a)
![Screenshot 2025-06-03 155516](https://github.com/user-attachments/assets/b7290052-5db7-4669-a03a-66acd74534bf)


updated statistics bar to be a single bar that changes according to stats that can be reused anywhere in the app with a code snipet // app/page.tsx
"use client";

import React from "react";
import ThemeToggle from "@/components/ThemeToggle";
import StatusBar, { StatusType } from "@/components/StatusBar";

export default function Home() {
  // For demonstration, you could change this state as needed:
  // const [currentStatus, setCurrentStatus] = React.useState<StatusType>("excellent");
  // Then pass `status={currentStatus}` to <StatusBar />.
  //
  // Here, we'll just render the default ("excellent").

  return (
    <div className="grid grid-rows-[20px_1fr_20px] min-h-screen p-8 pb-20 gap-16 sm:p-20 bg-white dark:bg-gray-900 transition-colors">
      <main className="flex flex-col gap-8 row-start-2 w-full max-w-xl mx-auto">
        <div className="flex justify-end">
          <ThemeToggle />
        </div>

        {/* Single reusable StatusBar with default "excellent" */}
        <div className="space-y-6">
          <StatusBar />
        </div>
      </main>
    </div>
  );
}
this is a example of the code useage and attached are new screenshots



 
![Screenshot 2025-06-03 174149](https://github.com/user-attachments/assets/96c5231f-a7b5-4aca-9fbc-4d17594c791e)
![Screenshot 2025-06-03 174119](https://github.com/user-attachments/assets/2fb15e70-2f94-4acb-8954-e3f4be90e3d5)
![Screenshot 2025-06-03 180742](https://github.com/user-attachments/assets/c63b4743-1e77-4027-a456-1ed8816c1134)
![Screenshot 2025-06-03 180715](https://github.com/user-attachments/assets/d19e1a98-d371-4f9b-bee5-f6d0dba94ae7)
