### PR TITLE
feat:created Header-with-Light/Dark mode and added title-subtitle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -17,4 +17,6 @@
   .animate-fadeIn {
     animation: fadeIn 0.4s ease-out forwards;
   }
+
+  
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,23 +1,30 @@
 import ThemeToggle from "@/components/ThemeToggle";
 import Image from "next/image";
-import MoodHistoryEntry, { MoodEntry } from "@/components/MoodHistoryEntry";
+// import MoodHistoryEntry, { MoodEntry } from "@/components/MoodHistoryEntry";
+import Header from "@/components/Header";
+
+
+
 export default function Home() {
-const sampleEntry: MoodEntry = {
-  mood: "Excellent",
-  date: new Date().toISOString(),
-  note: "Feeling great today!",
-};
+
+//   const sampleEntry: MoodEntry = {
+//   mood: "Excellent",
+//   date: new Date().toISOString(),
+//   note: "Feeling great today!",
+// };
 
 
 
   return (
-
+    <>
+<div><Header /></div>
   <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <ThemeToggle />
-      <MoodHistoryEntry entry={sampleEntry} />
+        {/* <ThemeToggle /> */}
+      {/* <MoodHistoryEntry entry={sampleEntry} /> */}
       </main>
     </div>
+    </>
 
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import ThemeToggle from "./ThemeToggle";
+
+export default function Header() {
+  return (
+    <header className="w-full bg-white dark:bg-[#0f172a] transition-colors duration-300">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between px-6 sm:px-12 lg:px-48 py-6 gap-4">
+        <div>
+          <h1 className="text-3xl sm:text-4xl font-bold bg-gradient-to-r from-purple-300 via-pink-600 to-red-500 text-transparent bg-clip-text">
+            Mood Tracker
+          </h1>
+          <h2 className="text-base sm:text-lg text-gray-600 dark:text-gray-400">
+            Track your daily emotions
+          </h2>
+        </div>
+        <ThemeToggle />
+      </div>
+    </header>
+  );
+}

--- a/components/Provider.tsx
+++ b/components/Provider.tsx
@@ -4,9 +4,12 @@ import { ThemeProvider } from 'next-themes';
 import React from 'react';
 
 export default function Provider({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
-    return <ThemeProvider attribute="class" defaultTheme="system">{children}</ThemeProvider>;
-}
+  children
+}: { children: React.ReactNode;
+}) {
+    return ( 
+    <ThemeProvider 
+    attribute="class" 
+    defaultTheme="system" enableSystem>{children}</ThemeProvider>
+)
+  }


### PR DESCRIPTION
Created a header component that uses light/dark toggle reusable component and context.  Has h-1 and h-2 html for title and subtitle. 

created off branch  feature/Header-with/Light/Dark-mode

ticket name Header with Light/Dark-mode

attached is mobile side by side as well as desktop side by side both light and dark mode :)
![Screenshot 2025-06-05 121659](https://github.com/user-attachments/assets/77024e7f-1d2e-4c93-a605-81be72568aa3)
![Screenshot 2025-06-05 121613](https://github.com/user-attachments/assets/2c50e78d-a9e9-4b0e-913f-6644befd72a5)
![Screenshot 2025-06-05 121504](https://github.com/user-attachments/assets/82d9a08a-4aa3-4698-ab65-2661deae124f)
